### PR TITLE
Add usage and deployment guides

### DIFF
--- a/Depploy_readme.md
+++ b/Depploy_readme.md
@@ -1,0 +1,27 @@
+# Deployment Guide
+
+This document explains how to deploy the two parts of the project.
+
+## Deploying the frontend to Netlify
+
+1. Build the React app:
+   ```bash
+   cd frontend
+   npm install
+   npm run build
+   ```
+   The production files are generated in the `dist/` directory.
+2. Sign in to [Netlify](https://www.netlify.com/) and create a new site from your repository.
+3. Set the **build command** to `npm run build` and the **publish directory** to `frontend/dist`.
+4. Deploy the site. Netlify will host the compiled files and provide a live URL.
+
+## Deploying the backend to Render
+
+1. Push this repository to a Git provider (GitHub, GitLab, etc.) if you haven't already.
+2. Create a new **Web Service** on [Render](https://render.com/) and connect your repo.
+3. Set the root directory to `backend`.
+4. Use the following commands when prompted:
+   - **Build Command**: `pip install -r requirements.txt && python manage.py migrate`
+   - **Start Command**: `python manage.py runserver 0.0.0.0:$PORT`
+5. Optionally configure environment variables such as `DJANGO_SECRET_KEY`.
+6. Render will build and launch the API, exposing a public URL for your backend.

--- a/README.md
+++ b/README.md
@@ -6,5 +6,25 @@ This repository contains:
 - **backend/** – a simple Django REST Framework (DRF) API.
 - **Jenkinsfile** – example pipeline for building and deploying both parts.
 
-Only a React frontend and a DRF backend are maintained.
-The frontend can be hosted on **Netlify** while the DRF backend can run on **Render**.
+Only a React frontend and a DRF backend are maintained. The frontend can be hosted on **Netlify** while the DRF backend can run on **Render**.
+
+## Running locally
+
+### Frontend
+```bash
+cd frontend
+npm install
+npm start
+```
+This starts a development server at `http://localhost:3000`.
+
+### Backend
+```bash
+cd backend
+pip install -r requirements.txt
+python manage.py migrate
+python manage.py runserver
+```
+The API will then be available at `http://localhost:8000/`.
+
+See `backend/README.md` for more backend information. Deployment instructions are available in `Depploy_readme.md`.


### PR DESCRIPTION
## Summary
- expand README with instructions for running the frontend and backend
- add a `Depploy_readme.md` with steps for deploying the React app to Netlify and the Django API to Render

## Testing
- `npm test` *(fails: Error: no test specified)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684ea0338e10832b963ae13c1262632d